### PR TITLE
feat: add static auth pages

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders login page by default', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /entrar/i });
+  expect(heading).toBeInTheDocument();
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,26 +1,16 @@
 import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+import Login from './pages/Login';
+import Cadastro from './pages/Cadastro';
 
 function App() {
-  return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
-  );
+  const pathname = window.location.pathname;
+  switch (pathname) {
+    case '/cadastro':
+      return <Cadastro />;
+    case '/login':
+    default:
+      return <Login />;
+  }
 }
 
 export default App;

--- a/frontend/src/components/ui/AuthCard.tsx
+++ b/frontend/src/components/ui/AuthCard.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface AuthCardProps {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}
+
+const AuthCard: React.FC<AuthCardProps> = ({ title, subtitle, children }) => {
+  return (
+    <div className="w-full max-w-md rounded-2xl border bg-card p-8 shadow-lg">
+      <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+      {subtitle && <p className="mt-2 text-sm text-muted-foreground">{subtitle}</p>}
+      <div className="mt-6 space-y-6">{children}</div>
+    </div>
+  );
+};
+
+export default AuthCard;

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'ghost';
+}
+
+const Button: React.FC<ButtonProps> = ({ variant = 'primary', className = '', ...props }) => {
+  const base = 'inline-flex w-full items-center justify-center rounded-lg px-4 py-2 text-sm font-medium focus:outline-none disabled:opacity-60';
+  const variants: Record<string, string> = {
+    primary: 'bg-primary text-primary-foreground hover:opacity-90',
+    ghost: 'border hover:bg-accent',
+  };
+  return <button className={`${base} ${variants[variant]} ${className}`} {...props} />;
+};
+
+export default Button;

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  error?: string;
+  hint?: string;
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ label, id, type = 'text', error, hint, className = '', ...props }, ref) => {
+    const baseClass = `w-full rounded-lg border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary focus:border-transparent ${error ? 'border-red-500' : ''} ${className}`;
+    return (
+      <div className="space-y-1">
+        <label htmlFor={id} className="block text-sm font-medium mb-1">
+          {label}
+        </label>
+        <input id={id} ref={ref} type={type} className={baseClass} {...props} />
+        {error ? (
+          <p className="mt-1 text-xs text-red-600 dark:text-red-400">{error}</p>
+        ) : hint ? (
+          <p className="mt-1 text-xs text-muted-foreground">{hint}</p>
+        ) : null}
+      </div>
+    );
+  }
+);
+
+Input.displayName = 'Input';
+
+export default Input;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,13 +1,7 @@
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+html, body, #root {
+  height: 100%;
 }

--- a/frontend/src/pages/Cadastro.tsx
+++ b/frontend/src/pages/Cadastro.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import AuthCard from '../components/ui/AuthCard';
+import Input from '../components/ui/Input';
+import Button from '../components/ui/Button';
+
+const Cadastro: React.FC = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [accept, setAccept] = useState(false);
+  const [errors, setErrors] = useState<{ name?: string; email?: string; password?: string; confirm?: string }>({});
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const newErrors: { name?: string; email?: string; password?: string; confirm?: string } = {};
+    if (!name) newErrors.name = 'Informe seu nome.';
+    if (!email) newErrors.email = 'Informe seu email.';
+    if (!password) newErrors.password = 'Informe sua senha.';
+    if (confirm !== password) newErrors.confirm = 'As senhas não correspondem.';
+    setErrors(newErrors);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background px-4">
+      <AuthCard title="Criar conta" subtitle="Cadastre-se para começar">
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <Input
+            label="Nome completo"
+            id="name"
+            type="text"
+            autoComplete="name"
+            placeholder="Seu nome"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            error={errors.name}
+          />
+          <Input
+            label="Email"
+            id="email"
+            type="email"
+            autoComplete="email"
+            placeholder="voce@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            error={errors.email}
+          />
+          <Input
+            label="Senha"
+            id="password"
+            type="password"
+            autoComplete="new-password"
+            placeholder="********"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            hint="Mínimo 8 caracteres."
+            error={errors.password}
+          />
+          <Input
+            label="Confirmar senha"
+            id="confirm"
+            type="password"
+            autoComplete="new-password"
+            placeholder="********"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            error={errors.confirm}
+          />
+          <label className="flex items-center space-x-2 text-sm">
+            <input
+              type="checkbox"
+              className="rounded border"
+              checked={accept}
+              onChange={(e) => setAccept(e.target.checked)}
+            />
+            <span>Aceito os Termos e a Política de Privacidade</span>
+          </label>
+          <Button type="submit">Criar conta</Button>
+          <div className="text-center text-sm text-muted-foreground">
+            Já tem conta?{' '}
+            <a href="/login" className="font-medium text-primary">
+              Entrar
+            </a>
+          </div>
+          <div className="text-center text-xs text-muted-foreground">
+            Integração com API virá aqui
+          </div>
+        </form>
+      </AuthCard>
+    </div>
+  );
+};
+
+export default Cadastro;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import AuthCard from '../components/ui/AuthCard';
+import Input from '../components/ui/Input';
+import Button from '../components/ui/Button';
+
+const Login: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [remember, setRemember] = useState(false);
+  const [errors, setErrors] = useState<{ email?: string; password?: string }>({});
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const newErrors: { email?: string; password?: string } = {};
+    if (!email) newErrors.email = 'Informe seu email.';
+    if (!password) newErrors.password = 'Informe sua senha.';
+    setErrors(newErrors);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background px-4">
+      <AuthCard title="Entrar" subtitle="Acesse sua conta">
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <Input
+            label="Email"
+            id="email"
+            type="email"
+            autoComplete="username"
+            placeholder="voce@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            error={errors.email}
+          />
+          <Input
+            label="Senha"
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            placeholder="********"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            error={errors.password}
+          />
+          <div className="flex items-center justify-between">
+            <label className="flex items-center space-x-2 text-sm">
+              <input
+                type="checkbox"
+                className="rounded border"
+                checked={remember}
+                onChange={(e) => setRemember(e.target.checked)}
+              />
+              <span>Lembrar de mim</span>
+            </label>
+            <a href="#" className="text-sm font-medium text-primary hover:underline">
+              Esqueci minha senha
+            </a>
+          </div>
+          <Button type="submit">Entrar</Button>
+          <div className="text-center text-sm text-muted-foreground">
+            Não tem conta?{' '}
+            <a href="/cadastro" className="font-medium text-primary">
+              Cadastre-se
+            </a>
+          </div>
+          <div className="text-center text-xs text-muted-foreground">
+            Integração com API virá aqui
+          </div>
+        </form>
+      </AuthCard>
+    </div>
+  );
+};
+
+export default Login;


### PR DESCRIPTION
## Summary
- add Tailwind-based AuthCard, Input, and Button components
- create static login and signup pages
- wire simple routing and update tests

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a7a756aa00833290164a8176687ce7