### PR TITLE
Add Python API with MySQL login and registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.log

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,68 @@
+import os
+from flask import Flask, request, jsonify
+import mysql.connector
+from mysql.connector import Error
+
+app = Flask(__name__)
+
+
+def get_db_connection():
+    return mysql.connector.connect(
+        host=os.getenv('DB_HOST', 'localhost'),
+        user=os.getenv('DB_USER', 'root'),
+        password=os.getenv('DB_PASSWORD', ''),
+        database=os.getenv('DB_NAME', 'traderbot')
+    )
+
+
+@app.route('/login', methods=['GET'])
+def login():
+    email = request.args.get('email')
+    password = request.args.get('password')
+    if not email or not password:
+        return jsonify({'error': 'missing credentials'}), 400
+
+    conn = get_db_connection()
+    cursor = conn.cursor(dictionary=True)
+    cursor.execute(
+        "SELECT id FROM users WHERE email=%s AND password=%s",
+        (email, password)
+    )
+    user = cursor.fetchone()
+    cursor.close()
+    conn.close()
+
+    if user:
+        return jsonify({'message': 'login successful'})
+    return jsonify({'error': 'invalid credentials'}), 401
+
+
+@app.route('/register', methods=['POST'])
+def register():
+    data = request.get_json() or {}
+    email = data.get('email')
+    password = data.get('password')
+    if not email or not password:
+        return jsonify({'error': 'missing data'}), 400
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO users (email, password) VALUES (%s, %s)",
+            (email, password)
+        )
+        conn.commit()
+    except Error as exc:
+        conn.rollback()
+        cursor.close()
+        conn.close()
+        return jsonify({'error': str(exc)}), 400
+
+    cursor.close()
+    conn.close()
+    return jsonify({'message': 'user created'}), 201
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/api/init_db.py
+++ b/api/init_db.py
@@ -1,0 +1,43 @@
+import os
+import mysql.connector
+
+
+def create_database():
+    connection = mysql.connector.connect(
+        host=os.getenv('DB_HOST', 'localhost'),
+        user=os.getenv('DB_USER', 'root'),
+        password=os.getenv('DB_PASSWORD', '')
+    )
+    cursor = connection.cursor()
+    db_name = os.getenv('DB_NAME', 'traderbot')
+    cursor.execute(f"CREATE DATABASE IF NOT EXISTS {db_name}")
+    cursor.close()
+    connection.close()
+
+
+def create_users_table():
+    connection = mysql.connector.connect(
+        host=os.getenv('DB_HOST', 'localhost'),
+        user=os.getenv('DB_USER', 'root'),
+        password=os.getenv('DB_PASSWORD', ''),
+        database=os.getenv('DB_NAME', 'traderbot')
+    )
+    cursor = connection.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            email VARCHAR(255) UNIQUE NOT NULL,
+            password VARCHAR(255) NOT NULL
+        )
+        """
+    )
+    connection.commit()
+    cursor.close()
+    connection.close()
+
+
+if __name__ == '__main__':
+    create_database()
+    create_users_table()
+    print('Database and users table created')

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+mysql-connector-python


### PR DESCRIPTION
## Summary
- add Flask API with GET /login and POST /register routes
- add MySQL database initialization script
- add requirements and gitignore

## Testing
- `python -m py_compile api/app.py api/init_db.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7a9f499f48332bbe925555764096f