### PR TITLE
Enable class-based dark mode

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -4,6 +4,15 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
+const rootElement = document.documentElement;
+const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+const handleThemeChange = (e: MediaQueryList | MediaQueryListEvent) => {
+  rootElement.classList.toggle('dark', e.matches);
+};
+
+handleThemeChange(mediaQuery);
+mediaQuery.addEventListener('change', handleThemeChange);
+
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}', './public/index.html'],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind to use class-based dark mode
- toggle the HTML `dark` class based on user theme

## Testing
- `cd frontend && CI=true npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a7af55637c83328511cf36100ef1fb