### PR TITLE
chore: streamline tailwind config

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,9 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [
-    './public/index.html',
-    './src/**/*.{js,jsx,ts,tsx}',
-  ],
+  content: ['./public/index.html', './src/**/*.{js,jsx,ts,tsx}'],
   darkMode: 'class',
   theme: {
     extend: {
@@ -19,25 +16,3 @@ module.exports = {
   },
   plugins: [],
 };
-
-        'muted-foreground': '#6b7280'
-      }
-    }
-  },
-  plugins: []
-};
-module.exports = {
-  content: ['./src/**/*.{js,jsx,ts,tsx}', './public/index.html'],
-  darkMode: 'class',
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: [
-    './public/index.html',
-    './src/**/*.{js,jsx,ts,tsx}',
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};
-}


### PR DESCRIPTION
## Summary
- clean up Tailwind CSS config to a single export

## Testing
- `npm run build`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a7b8d7880c83329174f301fa7a6dfb