### PR TITLE
Add dashboard page with trading chart

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import Login from './pages/Login';
 import Cadastro from './pages/Cadastro';
+import Dashboard from './pages/Dashboard';
 
 function App() {
   const pathname = window.location.pathname;
   switch (pathname) {
     case '/cadastro':
       return <Cadastro />;
+    case '/dashboard':
+      return <Dashboard />;
     case '/login':
     default:
       return <Login />;

--- a/frontend/src/components/TradingViewWidget.tsx
+++ b/frontend/src/components/TradingViewWidget.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useRef, memo } from 'react';
+
+function TradingViewWidget() {
+  const container = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!container.current) return;
+    const script = document.createElement('script');
+    script.src = 'https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js';
+    script.type = 'text/javascript';
+    script.async = true;
+    script.innerHTML = `{
+      "allow_symbol_change": true,
+      "calendar": false,
+      "details": false,
+      "hide_side_toolbar": true,
+      "hide_top_toolbar": false,
+      "hide_legend": false,
+      "hide_volume": false,
+      "hotlist": false,
+      "interval": "1",
+      "locale": "br",
+      "save_image": true,
+      "style": "1",
+      "symbol": "OANDA:EURUSD",
+      "theme": "dark",
+      "timezone": "Etc/UTC",
+      "backgroundColor": "#0F0F0F",
+      "gridColor": "rgba(242, 242, 242, 0.06)",
+      "watchlist": [],
+      "withdateranges": false,
+      "compareSymbols": [],
+      "studies": [],
+      "autosize": true
+    }`;
+    container.current.appendChild(script);
+  }, []);
+
+  return (
+    <div
+      className="tradingview-widget-container"
+      ref={container}
+      style={{ height: '100%', width: '100%' }}
+    >
+      <div
+        className="tradingview-widget-container__widget"
+        style={{ height: 'calc(100% - 32px)', width: '100%' }}
+      ></div>
+      <div className="tradingview-widget-copyright">
+        <a
+          href="https://br.tradingview.com/symbols/OANDA-EURUSD/?exchange=OANDA"
+          rel="noopener nofollow"
+          target="_blank"
+        >
+          <span className="blue-text">Track all markets on TradingView</span>
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default memo(TradingViewWidget);
+

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import TradingViewWidget from '../components/TradingViewWidget';
+import Button from '../components/ui/Button';
+
+const Dashboard: React.FC = () => {
+  const user = {
+    name: 'Usuário',
+    email: 'usuario@example.com',
+  };
+
+  return (
+    <div className="min-h-screen bg-background text-gray-800">
+      <header className="flex items-center justify-between bg-card p-4 shadow">
+        <h1 className="text-xl font-bold">TraderBot</h1>
+        <div className="flex items-center space-x-4">
+          <div className="text-right text-sm">
+            <div>{user.name}</div>
+            <div className="text-muted-foreground">{user.email}</div>
+          </div>
+          <Button className="w-auto" onClick={() => (window.location.href = '/config')}>Configurações</Button>
+        </div>
+      </header>
+      <main className="space-y-6 p-4">
+        <div className="h-96 w-full">
+          <TradingViewWidget />
+        </div>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="rounded-lg bg-card p-4 shadow">
+            <h2 className="mb-2 text-lg font-semibold">Catalogador de Sinais</h2>
+            <p className="text-sm text-muted-foreground">
+              Conteúdo de análise de sinais históricos.
+            </p>
+          </div>
+          <div className="rounded-lg bg-card p-4 shadow">
+            <h2 className="mb-2 text-lg font-semibold">Análise em Tempo Real</h2>
+            <p className="text-sm text-muted-foreground">
+              Conteúdo de análise em tempo real.
+            </p>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default Dashboard;
+

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -15,6 +15,9 @@ const Login: React.FC = () => {
     if (!email) newErrors.email = 'Informe seu email.';
     if (!password) newErrors.password = 'Informe sua senha.';
     setErrors(newErrors);
+    if (Object.keys(newErrors).length === 0) {
+      window.location.href = '/dashboard';
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- create trading view widget component and dashboard page
- add dashboard route and redirect after login

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts: not found; npm install returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bf3e2e2c83328a5d7ff1538739b0