### PR TITLE
fix: guard TradingViewWidget container ref

### DIFF
--- a/frontend/src/components/TradingViewWidget.tsx
+++ b/frontend/src/components/TradingViewWidget.tsx
@@ -8,7 +8,6 @@ function TradingViewWidget() {
     if (!containerEl) return;
 
     containerEl.innerHTML = '';
-    if (!container.current) return;
     const script = document.createElement('script');
     script.src = 'https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js';
     script.type = 'text/javascript';
@@ -42,7 +41,6 @@ function TradingViewWidget() {
     return () => {
       containerEl.innerHTML = '';
     };
-    container.current.appendChild(script);
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- store `container.current` in a local var and bail if null
- use the local container element for `appendChild` and cleanup to avoid TS18047

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a7c657c2c8833281712eec5641b507