### PR TITLE
Handle TradingView script load errors

### DIFF
--- a/frontend/src/components/TradingViewWidget.tsx
+++ b/frontend/src/components/TradingViewWidget.tsx
@@ -8,11 +8,14 @@ function TradingViewWidget() {
     if (!containerEl) return;
 
     containerEl.innerHTML = '';
-    if (!container.current) return;
     const script = document.createElement('script');
-    script.src = 'https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js';
     script.type = 'text/javascript';
     script.async = true;
+    script.crossOrigin = 'anonymous';
+    script.src = 'https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js';
+    script.onerror = (e) => {
+      console.error('TradingView widget failed to load', e);
+    };
     script.innerHTML = `{
       "allow_symbol_change": true,
       "calendar": false,
@@ -42,7 +45,21 @@ function TradingViewWidget() {
     return () => {
       containerEl.innerHTML = '';
     };
-    container.current.appendChild(script);
+  }, []);
+
+  useEffect(() => {
+    const handleWindowError = (event: ErrorEvent) => {
+      if (event.message === 'Script error.' && event.filename === '') {
+        console.error('Cross-origin script error', event);
+        event.preventDefault();
+        event.stopImmediatePropagation();
+      }
+    };
+
+    window.addEventListener('error', handleWindowError, true);
+    return () => {
+      window.removeEventListener('error', handleWindowError, true);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- add error handler for TradingView widget script and mark script as cross-origin
- suppress generic cross-origin "Script error" by catching it on window

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a7c657c2c8833281712eec5641b507