### PR TITLE
fix TradingView widget error handler

### DIFF
--- a/frontend/src/components/TradingViewWidget.tsx
+++ b/frontend/src/components/TradingViewWidget.tsx
@@ -60,13 +60,6 @@ function TradingViewWidget() {
     return () => {
       window.removeEventListener('error', handleWindowError, true);
     };
-      }
-    };
-
-    window.addEventListener('error', handleWindowError);
-    return () => {
-      window.removeEventListener('error', handleWindowError);
-    };
 
   }, []);
 


### PR DESCRIPTION
## Summary
- remove duplicated window error listeners
- ensure TradingView error handler registers with proper cleanup

## Testing
- `CI=true npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7d14044c88332a20c4de97da28b27