### PR TITLE
Integrate IQ Option login

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 mysql-connector-python
+iqoptionapi

--- a/frontend/public/css/panel.css
+++ b/frontend/public/css/panel.css
@@ -1,0 +1,12 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f4f7fa;
+}
+
+/* basic panel style */
+.auth-card {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,6 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <link rel="stylesheet" href="%PUBLIC_URL%/css/panel.css" />
     <title>React App</title>
   </head>
   <body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ function App() {
       return <Cadastro />;
     case '/dashboard':
       return <Dashboard />;
+    case '/':
     case '/login':
     default:
       return <Login />;

--- a/frontend/src/components/ui/AuthCard.tsx
+++ b/frontend/src/components/ui/AuthCard.tsx
@@ -8,7 +8,7 @@ interface AuthCardProps {
 
 const AuthCard: React.FC<AuthCardProps> = ({ title, subtitle, children }) => {
   return (
-    <div className="w-full max-w-md rounded-2xl border bg-card p-8 shadow-lg">
+    <div className="auth-card w-full max-w-md rounded-2xl border bg-card p-8 shadow-lg">
       <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
       {subtitle && <p className="mt-2 text-sm text-muted-foreground">{subtitle}</p>}
       <div className="mt-6 space-y-6">{children}</div>

--- a/frontend/src/pages/Cadastro.tsx
+++ b/frontend/src/pages/Cadastro.tsx
@@ -11,7 +11,7 @@ const Cadastro: React.FC = () => {
   const [accept, setAccept] = useState(false);
   const [errors, setErrors] = useState<{ name?: string; email?: string; password?: string; confirm?: string }>({});
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const newErrors: { name?: string; email?: string; password?: string; confirm?: string } = {};
     if (!name) newErrors.name = 'Informe seu nome.';
@@ -19,6 +19,23 @@ const Cadastro: React.FC = () => {
     if (!password) newErrors.password = 'Informe sua senha.';
     if (confirm !== password) newErrors.confirm = 'As senhas não correspondem.';
     setErrors(newErrors);
+    if (Object.keys(newErrors).length === 0) {
+      try {
+        const response = await fetch('http://localhost:5000/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password }),
+        });
+        const data = await response.json();
+        if (data.message) {
+          window.location.href = '/login';
+        } else {
+          setErrors({ email: data.error || 'Falha no cadastro.' });
+        }
+      } catch (err) {
+        setErrors({ email: 'Erro de conexão com o servidor.' });
+      }
+    }
   };
 
   return (
@@ -81,9 +98,6 @@ const Cadastro: React.FC = () => {
             <a href="/login" className="font-medium text-primary">
               Entrar
             </a>
-          </div>
-          <div className="text-center text-xs text-muted-foreground">
-            Integração com API virá aqui
           </div>
         </form>
       </AuthCard>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -9,14 +9,28 @@ const Login: React.FC = () => {
   const [remember, setRemember] = useState(false);
   const [errors, setErrors] = useState<{ email?: string; password?: string }>({});
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const newErrors: { email?: string; password?: string } = {};
     if (!email) newErrors.email = 'Informe seu email.';
     if (!password) newErrors.password = 'Informe sua senha.';
     setErrors(newErrors);
     if (Object.keys(newErrors).length === 0) {
-      window.location.href = '/dashboard';
+      try {
+        const response = await fetch('http://localhost:5000/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password }),
+        });
+        const data = await response.json();
+        if (data.message) {
+          window.location.href = '/dashboard';
+        } else {
+          setErrors({ password: data.error || 'Falha no login.' });
+        }
+      } catch (err) {
+        setErrors({ password: 'Erro de conexão com o servidor.' });
+      }
     }
   };
 
@@ -64,9 +78,6 @@ const Login: React.FC = () => {
             <a href="/cadastro" className="font-medium text-primary">
               Cadastre-se
             </a>
-          </div>
-          <div className="text-center text-xs text-muted-foreground">
-            Integração com API virá aqui
           </div>
         </form>
       </AuthCard>


### PR DESCRIPTION
## Summary
- hash stored passwords and connect to IQ Option API
- wire frontend login to backend and add panel styling
- switch login to JSON POST and hook registration form to backend

## Testing
- `python -m py_compile api/app.py api/init_db.py`
- `npm test --prefix frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b6423a7dc483329a367de17d36ca0c